### PR TITLE
Update runtime to GNOME 46

### DIFF
--- a/edu.berkeley.BOINC.yml
+++ b/edu.berkeley.BOINC.yml
@@ -1,6 +1,6 @@
 app-id: edu.berkeley.BOINC
 runtime: org.gnome.Platform
-runtime-version: "44"
+runtime-version: "46"
 sdk: org.gnome.Sdk
 command: boincmgr
 finish-args:


### PR DESCRIPTION
Switch runtime to org.gnome.Platform 46 since 44 is now EoL

Fixes https://github.com/flathub/edu.berkeley.BOINC/issues/16