### PR TITLE
Update runtime to GNOME 48

### DIFF
--- a/edu.berkeley.BOINC.yml
+++ b/edu.berkeley.BOINC.yml
@@ -1,6 +1,7 @@
 app-id: edu.berkeley.BOINC
 runtime: org.gnome.Platform
 runtime-version: "48"
+##### test comment
 sdk: org.gnome.Sdk
 command: boincmgr
 finish-args:

--- a/edu.berkeley.BOINC.yml
+++ b/edu.berkeley.BOINC.yml
@@ -1,6 +1,6 @@
 app-id: edu.berkeley.BOINC
 runtime: org.gnome.Platform
-runtime-version: "46"
+runtime-version: "48"
 sdk: org.gnome.Sdk
 command: boincmgr
 finish-args:

--- a/edu.berkeley.BOINC.yml
+++ b/edu.berkeley.BOINC.yml
@@ -1,7 +1,6 @@
 app-id: edu.berkeley.BOINC
 runtime: org.gnome.Platform
 runtime-version: "48"
-##### test comment
 sdk: org.gnome.Sdk
 command: boincmgr
 finish-args:


### PR DESCRIPTION
Fixes: https://github.com/flathub/edu.berkeley.BOINC/issues/22 (GNOME 46 runtime is no longer supported as of April 17, 2025)

@AenBleidd 